### PR TITLE
add support for SOK 48v rack battery

### DIFF
--- a/Code/Python/pylon_to_mqtt.py
+++ b/Code/Python/pylon_to_mqtt.py
@@ -12,6 +12,7 @@ from enum import Enum
 from support.pylon_jsonencoder import encodePylon_readings, encodePylon_info
 from support.pylon_validate import handleArgs
 from support.pylontech import Pylontech
+from support.pylontech import PylonTechSOK
 from time import time_ns
 
 # --------------------------------------------------------------------------- # 
@@ -39,7 +40,8 @@ argumentValues = { \
     'mqttRoot':os.getenv('MQTT_ROOT', "PylonToMQTT"), \
     'mqttUser':os.getenv('MQTT_USER', ""), \
     'mqttPassword':os.getenv('MQTT_PASS', ""), \
-    'publishRate':int(os.getenv('PUBLISH_RATE', str(DEFAULT_WAKE_RATE)))
+    'publishRate':int(os.getenv('PUBLISH_RATE', str(DEFAULT_WAKE_RATE))), \
+    'sok':bool(os.getenv("SOK", ""))    # default is false (Jakiper battery)
 }
 
 # --------------------------------------------------------------------------- # 
@@ -222,7 +224,11 @@ def periodic(polling_stop):
         try:
             if mqttConnected:
                 if pylontech is None:
-                    pylontech = Pylontech(argumentValues['pylonPort'], int(argumentValues['baud_rate']))
+                    if argumentValues['sok']:
+                        pylontech = PylonTechSOK(argumentValues['pylonPort'], int(argumentValues['baud_rate']))
+                    else:
+                        pylontech = Pylontech(argumentValues['pylonPort'], int(argumentValues['baud_rate']))
+
                 data = {}
                 if number_of_packs == 0:
                     number_of_packs = pylontech.get_pack_count().PackCount

--- a/Code/Python/support/pylon_validate.py
+++ b/Code/Python/support/pylon_validate.py
@@ -49,6 +49,15 @@ def validateIntParameter(param, name, defaultValue):
         return defaultValue
     return temp
 
+def validateBoolParamter(param, name, defaultValue):
+    try:
+        temp = bool(param)
+    except Exception as e:
+        log.error("Invalid parameter, {} passed for {}".format(param, name))
+        log.exception(e, exc_info=False)
+        return defaultValue
+    return temp
+
 
 # --------------------------------------------------------------------------- # 
 # Handle the command line arguments
@@ -67,15 +76,16 @@ def handleArgs(argv,argVals):
                      "mqtt_root=",
                      "mqtt_user=",
                      "mqtt_pass=",
-                     "publish_rate="])
+                     "publish_rate=",
+                     "sok="])
     except getopt.GetoptError:
-        print("Error parsing command line parameters, please use: py --pylon_port <{}> --baud_rate <{}> --rack_name <{}> --mqtt_host <{}> --mqtt_port <{}> --mqtt_root <{}> --mqtt_user <username> --mqtt_pass <password> --publish_rate <{}>".format( \
-                   argVals['pylonPort'], argVals['baud_rate'], argVals['rack_name'], argVals['mqttHost'], argVals['mqttPort'], argVals['mqttRoot'], argVals['publishRate']))
+        print("Error parsing command line parameters, please use: py --pylon_port <{}> --baud_rate <{}> --rack_name <{}> --mqtt_host <{}> --mqtt_port <{}> --mqtt_root <{}> --mqtt_user <username> --mqtt_pass <password> --publish_rate <{}> --sok <{}>".format( \
+                   argVals['pylonPort'], argVals['baud_rate'], argVals['rack_name'], argVals['mqttHost'], argVals['mqttPort'], argVals['mqttRoot'], argVals['publishRate'], argVals['sok']))
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print ("Parameter help: py --pylon_port <{}> --baud_rate <{}> --rackName <{}> --mqtt_host <{}> --mqtt_port <{}> --mqtt_root <{}> --mqtt_user <username> --mqtt_pass <password> --publish_rate <{}>".format( \
-                    argVals['pylonPort'], argVals['baud_rate'], argVals['rackName'], argVals['mqttHost'], argVals['mqttPort'], argVals['mqttRoot'], argVals['publishRate']))
+            print ("Parameter help: py --pylon_port <{}> --baud_rate <{}> --rackName <{}> --mqtt_host <{}> --mqtt_port <{}> --mqtt_root <{}> --mqtt_user <username> --mqtt_pass <password> --publish_rate <{}> --sok <{}>".format( \
+                    argVals['pylonPort'], argVals['baud_rate'], argVals['rackName'], argVals['mqttHost'], argVals['mqttPort'], argVals['mqttRoot'], argVals['publishRate'], argVals['sok']))
             sys.exit()
         elif opt in ('--pylon_port'):
             argVals['pylonPort'] = validateStrParameter(arg,"pylon_port", argVals['pylonPort'])
@@ -95,6 +105,8 @@ def handleArgs(argv,argVals):
             argVals['mqttPassword'] = validateStrParameter(arg,"mqtt_pass", argVals['mqttPassword'])
         elif opt in ("--publish_rate"):
             argVals['publishRate'] = int(validateIntParameter(arg,"publish_rate", argVals['publishRate']))
+        elif opt in ("--sok"):
+            argVals['sok'] = bool(validateBoolParamter(arg, "sok", argVals['sok']))
 
     if ((argVals['publishRate'])<MIN_PUBLISH_RATE):
         print("--publishRate must be greater than or equal to {} seconds".format(MIN_PUBLISH_RATE))
@@ -119,6 +131,7 @@ def handleArgs(argv,argVals):
     log.info("mqttPassword = **********")
     #log.info("mqttPassword = {}".format(argVals['mqttPassword']))
     log.info("publishRate = {}".format(argVals['publishRate']))
+    log.info("sok = {}".format(argVals['sok']))
 
     #Make sure the last character in the root is a "/"
     if (not argVals['mqttRoot'].endswith("/")):


### PR DESCRIPTION
this PR adds support for the [SOK 48v server rack battery](https://www.currentconnected.com/product/sk48v100/).

to run the application with sok batteries, add the following option when executing the main python script: `--sok true`.

e.g.:
```bash
python3 PylonToMQTT-main/Code/Python/pylon_to_mqtt.py --pylon_port /dev/ttyUSB0 --baud_rate 9600 --rack_name sok_rack --mqtt_host 127.0.0.1 --mqtt_root Main --mqtt_user user --mqtt_pass password --publish_rate 5 --sok true
```

### Note: 
the `--sok` option defaults to `false`, so the Jakiper battery type is assumed if the option is not used. 
i.e. - this PR is backwards compatible.